### PR TITLE
Rename the COVIDpass email for the healthcenter alert

### DIFF
--- a/local/mxschool/classes/local/healthpass/healthcenter_notification.php
+++ b/local/mxschool/classes/local/healthpass/healthcenter_notification.php
@@ -63,7 +63,7 @@ class healthcenter_notification extends \local_mxschool\notification {
 		  $this->data['body_temperature'] = $record->body_temperature;
 
 		  $healthcenter = $DB->get_record('user', array('id' => 2));
-		  $healthcenter->email = get_config('local_mxschool', 'healthcenter_notification_email_address');
+		  $healthcenter->email = get_config('local_mxschool', 'healthpass_notification_email_address');
 		  $healthcenter->addresseename = 'Health Center';
 		  $healthcenter->firstname = 'Health';
 		  $healthcenter->lastname = 'Center';

--- a/local/mxschool/healthpass/preferences.php
+++ b/local/mxschool/healthpass/preferences.php
@@ -41,7 +41,7 @@ $data->one_per_day = get_config('local_mxschool', 'healthpass_one_per_day');
 
 $data->max_body_temp = get_config('local_mxschool', 'healthpass_max_body_temp');
 $data->healthcenter_notification_enabled = get_config('local_mxschool', 'healthcenter_notification_enabled');
-$data->healthcenter_email_address = get_config('local_mxschool', 'healthcenter_notification_email_address');
+$data->healthcenter_email_address = get_config('local_mxschool', 'healthpass_notification_email_address');
 $data->days_before_reminder = get_config('local_mxschool', 'healthpass_days_before_reminder');
 generate_email_preference_fields('healthcenter_notification', $data, 'healthcenter');
 generate_email_preference_fields('healthpass_approved', $data, 'approved');
@@ -63,7 +63,7 @@ if ($form->is_cancelled()) { // If the cancel button is pressed...
 	set_config('healthpass_enabled', $data->healthpass_enabled, 'local_mxschool');
 	set_config('healthpass_max_body_temp', $data->max_body_temp, 'local_mxschool');
 	set_config('healthcenter_notification_enabled', $data->healthcenter_notification_enabled, 'local_mxschool');
-	set_config('healthcenter_notification_email_address', $data->healthcenter_email_address, 'local_mxschool');
+	set_config('healthpass_notification_email_address', $data->healthcenter_email_address, 'local_mxschool');
 	set_config('healthpass_days_before_reminder', $data->days_before_reminder, 'local_mxschool');
 	set_config('healthpass_one_per_day', $data->one_per_day, 'local_mxschool');
      update_notification('healthcenter_notification', $data, 'healthcenter');

--- a/local/mxschool/lang/en/local_mxschool.php
+++ b/local/mxschool/lang/en/local_mxschool.php
@@ -1179,7 +1179,7 @@ $string['deans_permission:event_edit:info:event_name'] = 'Event Type Name';
  $string['healthpass:preferences:preferences:max_body_temp'] = 'Highest allowable body temperature';
 
  $string['healthpass:preferences:healthcenter_notification:healthcenter_notification_enabled'] = 'Enable email notifications to the Health Center when a COVIDpass is denied';
- $string['healthpass:preferences:healthcenter_notification:healthcenter_email_address'] = 'Healthcenter email';
+ $string['healthpass:preferences:healthcenter_notification:healthcenter_email_address'] = 'Health Center email';
  $string['healthpass:preferences:healthcenter_notification:healthcenter_tags'] = 'Available tags for COVIDpass healthcenter notification email';
  $string['healthpass:preferences:healthcenter_notification:healthcenter_subject'] = 'Healthcenter notification email subject';
  $string['healthpass:preferences:healthcenter_notification:healthcenter_body'] = 'Healthcenter notification email body';

--- a/local/mxschool/version.php
+++ b/local/mxschool/version.php
@@ -27,8 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_mxschool';
-// $plugin->version = 2020083101;
-$plugin->version = 2021031801;
+$plugin->version = 2021042000;
 $plugin->release = 'v3.2';
 $plugin->requires = 2019052000; // Moodle 3.7.
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This needs to be separated so that the COVIDtest email can use a unique email address.
Co-Authored-By: AaravMehta4897 <58570210+AaravMehta4897@users.noreply.github.com>