### PR TITLE
Added unique COVIDtest email

### DIFF
--- a/local/mxschool/classes/local/healthtest/healthtest_notification.php
+++ b/local/mxschool/classes/local/healthtest/healthtest_notification.php
@@ -70,7 +70,7 @@ abstract class healthtest_notification extends \local_mxschool\notification {
 
 		  if($emailclass == 'healthtest_missed' and get_config('local_mxschool', 'healthtest_copy_healthcenter')=='1') {
 			  $healthcenter = $DB->get_record('user', array('id' => 2));
-			  $healthcenter->email = get_config('local_mxschool', 'healthcenter_notification_email_address');
+			  $healthcenter->email = get_config('local_mxschool', 'healthtest_notification_email_address');
 			  $healthcenter->addresseename = 'Health Center';
 			  $healthcenter->firstname = 'Health';
 			  $healthcenter->lastname = 'Center';

--- a/local/mxschool/classes/local/healthtest/preferences_form.php
+++ b/local/mxschool/classes/local/healthtest/preferences_form.php
@@ -56,6 +56,7 @@
 			 ),
 			 'missed_notification' => array(
 				'missed_copy_healthcenter_enabled' => array('element' => 'checkbox'),
+                'healthcenter_email_address' => self::ELEMENT_LONG_TEXT_REQUIRED,
 				'missed_tags' => self::email_tags(new healthtest_missed()),
 				'missed_subject' => self::ELEMENT_LONG_TEXT_REQUIRED,
 				'missed_body' => self::ELEMENT_FORMATTED_TEXT_REQUIRED

--- a/local/mxschool/db/upgrade.php
+++ b/local/mxschool/db/upgrade.php
@@ -1245,6 +1245,11 @@ function xmldb_local_mxschool_upgrade($oldversion) {
 		upgrade_plugin_savepoint(true, 2021031203, 'local', 'mxschool');
 	}
 
+    if($oldversion < 2021042000) {
+        unset_config('healthcenter_notification_email_address', 'local_mxschool');
+        set_config('healthpass_notification_email_address', 'healthcenter@mxschool.edu', 'local_mxschool');
+        set_config('healthtest_notification_email_address', 'healthcenter@mxschool.edu', 'local_mxschool');
+    }
 
      return true;
 

--- a/local/mxschool/healthtest/preferences.php
+++ b/local/mxschool/healthtest/preferences.php
@@ -40,6 +40,7 @@ $data->healthtest_enabled = get_config('local_mxschool', 'healthtest_enabled');
 $data->form_instructions = get_config('local_mxschool', 'healthtest_form_instructions');
 // $data->reminder_enabled = get_config('local_mxschool', 'healthtest_reminder_enabled');
 $data->missed_copy_healthcenter_enabled = get_config('local_mxschool', 'healthtest_copy_healthcenter');
+$data->healthcenter_email_address = get_config('local_mxschool', 'healthtest_notification_email_address');
 $data->confirm_enabled = get_config('local_mxschool', 'healthtest_confirm_enabled');
 
 generate_email_preference_fields('healthtest_reminder', $data, 'reminder');
@@ -61,6 +62,7 @@ if ($form->is_cancelled()) { // If the cancel button is pressed...
 	set_config('healthtest_form_instructions', $data->form_instructions, 'local_mxschool');
 	// set_config('healthtest_reminder_enabled', $data->reminder_enabled, 'local_mxschool');
 	set_config('healthtest_copy_healthcenter', $data->missed_copy_healthcenter_enabled, 'local_mxschool');
+    set_config('healthtest_notification_email_address', $data->healthcenter_email_address, 'local_mxschool');
 	set_config('healthtest_confirm_enabled', $data->confirm_enabled, 'local_mxschool');
 
      update_notification('healthtest_reminder', $data, 'reminder');

--- a/local/mxschool/lang/en/local_mxschool.php
+++ b/local/mxschool/lang/en/local_mxschool.php
@@ -1284,6 +1284,7 @@ $string['deans_permission:event_edit:info:event_name'] = 'Event Type Name';
  $string['healthtest:preferences:reminder_notification:reminder_body'] = 'Reminder notification email body';
 
  $string['healthtest:preferences:missed_notification:missed_copy_healthcenter_enabled'] = 'Copy Healthcenter on missed test notification';
+ $string['healthtest:preferences:missed_notification:healthcenter_email_address'] = 'Health Center email';
  $string['healthtest:preferences:missed_notification:missed_tags'] = 'Available tags for test missed notification';
  $string['healthtest:preferences:missed_notification:missed_subject'] = 'Testing missed notification email subject';
  $string['healthtest:preferences:missed_notification:missed_body'] = 'Testing missed notification email body';

--- a/local/mxschool/version.php
+++ b/local/mxschool/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_mxschool';
-$plugin->version = 2021042000;
+$plugin->version = 2021042002;
 $plugin->release = 'v3.2';
 $plugin->requires = 2019052000; // Moodle 3.7.
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Add unique Health Centre email address to missed COVIDtest notification

Co-Authored-By: AaravMehta4897 <58570210+AaravMehta4897@users.noreply.github.com>