### PR TITLE
Update locallib.php

### DIFF
--- a/local/signout/locallib.php
+++ b/local/signout/locallib.php
@@ -161,7 +161,7 @@ function get_permitted_passenger_list($userid = 0) {
         "SELECT u.id, CONCAT(u.lastname, ', ', u.firstname) AS name
          FROM {local_mxschool_student} s LEFT JOIN {user} u ON s.userid = u.id
                                          LEFT JOIN {local_mxschool_permissions} p ON s.userid = p.userid
-         WHERE u.deleted = 0 AND u.id <> ? AND s.grade >= 11 AND p.may_ride_with_anyone <> 'No'
+         WHERE u.deleted = 0 AND u.id <> ? AND s.grade >= 11 AND p.may_drive_with_anyone <> 'No'
          ORDER BY name", array($userid)
     );
     return convert_student_records_to_list($students);


### PR DESCRIPTION
drive v ride
This is a change we once talked about that appears to have crept in from somewhere.

mdl_local_mxschool_permissions has two fields:
may_drive_with_over_21
may_drive_with_anyone

It makes sense for both of these to be "ride" and not "drive" but this one change snuck in. I'm changing it back to "drive" and we can address this later in a testing environement.