### PR TITLE
107 advisor functionality

### DIFF
--- a/blocks/mxschool_dash_faculty/README.md
+++ b/blocks/mxschool_dash_faculty/README.md
@@ -20,16 +20,16 @@ This plugin has the following dependencies:
 - [local_peertutoring v4.0](/local/peertutoring/README.md) (2022___)
 
 ## Credits
-v4.0 of this plugin was developed alongside v4.0 of the local_mxschool plugin in 2022 by:
+v4.0 of this plugin was developed alongside v4.0 of the local_mxschool plugin in 2022 by:  
 Aarav Mehta, Class of 2023 \<amehta@mxschool.edu\>  
 Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>  
 The mxMoodle Development Team
 
-v3.2 of this plugin was developed alongside v3.2 of the local_mxschool plugin in 2020 by:
+v3.2 of this plugin was developed alongside v3.2 of the local_mxschool plugin in 2020 by:  
 Cannon Caspar, Class of 2021 \<cpcaspar@mxschool.edu\>  
 Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 
-v3.1 of this plugin was developed alongside v3.1 of the local_mxschool plugin in 2019 by:
+v3.1 of this plugin was developed alongside v3.1 of the local_mxschool plugin in 2019 by:  
 Jeremiah DeGreeff, Class of 2019 \<jrdegreeff@mxschool.edu\>  
 Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 

--- a/blocks/mxschool_dash_faculty/README.md
+++ b/blocks/mxschool_dash_faculty/README.md
@@ -20,16 +20,16 @@ This plugin has the following dependencies:
 - [local_peertutoring v4.0](/local/peertutoring/README.md) (2022___)
 
 ## Credits
-v4.0 of this plugin was developed alongside v4.0 of the local_mxschool plugin in 2022 by:  
+v4.0 of this plugin was developed alongside v4.0 of the local_mxschool plugin in 2022 by:
 Aarav Mehta, Class of 2023 \<amehta@mxschool.edu\>  
 Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>  
 The mxMoodle Development Team
 
-v3.2 of this plugin was developed alongside v3.2 of the local_mxschool plugin in 2020 by:  
+v3.2 of this plugin was developed alongside v3.2 of the local_mxschool plugin in 2020 by:
 Cannon Caspar, Class of 2021 \<cpcaspar@mxschool.edu\>  
 Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 
-v3.1 of this plugin was developed alongside v3.1 of the local_mxschool plugin in 2019 by:  
+v3.1 of this plugin was developed alongside v3.1 of the local_mxschool plugin in 2019 by:
 Jeremiah DeGreeff, Class of 2019 \<jrdegreeff@mxschool.edu\>  
 Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 

--- a/blocks/mxschool_dash_faculty/README.md
+++ b/blocks/mxschool_dash_faculty/README.md
@@ -1,6 +1,16 @@
-# Middlesex's Dashboard Block for Faculty.
-## Package Description
-This block provides an interface for all faculty to access reports defined by the local_mxschool, local_signout, and local_peertutoring plugins.
+# Middlesex Faculty Dashboard Block
+## Description
+This block is for all faculty and provides links to reports defined by the local_mxschool, local_signout, and local_peertutoring plugins.
+
+Student Data reports:
+- My Advisees: This is the student data report filtered by the Faculty's advisees. If the Faculty does not have advisees, then the report will default to All Advisors
+- My Dorm: This is the student data report filtered by the Faculty's assigned dorm. If the Faculty does not have an assigned dorm, then the report will default to All Dorms
+- Peer Tutoring: This is the Peer Tutoring report
+- Student Vehicles: Student Vehicle report
+
+Check In reports:
+- Event Attendance: This is the general attendance report defaulting to the Faculty's assigned dorm. If the Faculty does not have an assigned dorm, then the report will default to All Dorms.
+- On-Campus Duty Report
 
 ## Dependencies
 This plugin has the following dependencies:
@@ -11,7 +21,7 @@ This plugin has the following dependencies:
 
 ## Credits
 v4.0 of this plugin was developed alongside v4.0 of the local_mxschool plugin in 2022 by:
-- Aarav Mehta, Class of 2023
+- Aarav Mehta, Class of 2023 \<amehta@mxschool.edu\>
 - Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 - The mxMoodle Development Team
 

--- a/blocks/mxschool_dash_faculty/README.md
+++ b/blocks/mxschool_dash_faculty/README.md
@@ -21,17 +21,17 @@ This plugin has the following dependencies:
 
 ## Credits
 v4.0 of this plugin was developed alongside v4.0 of the local_mxschool plugin in 2022 by:
-Aarav Mehta, Class of 2023 \<amehta@mxschool.edu\>  
-Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>  
-The mxMoodle Development Team
+- Aarav Mehta, Class of 2023 \<amehta@mxschool.edu\>
+- Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
+- The mxMoodle Development Team
 
 v3.2 of this plugin was developed alongside v3.2 of the local_mxschool plugin in 2020 by:
-Cannon Caspar, Class of 2021 \<cpcaspar@mxschool.edu\>  
-Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
+- Cannon Caspar, Class of 2021 \<cpcaspar@mxschool.edu\>
+- Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 
 v3.1 of this plugin was developed alongside v3.1 of the local_mxschool plugin in 2019 by:
-Jeremiah DeGreeff, Class of 2019 \<jrdegreeff@mxschool.edu\>  
-Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
+- Jeremiah DeGreeff, Class of 2019 \<jrdegreeff@mxschool.edu\>
+- Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 
 ## License
 As Moodle itself, this plugin is provided freely under the [GNU General Public License v3.0](/COPYING.txt).  

--- a/blocks/mxschool_dash_faculty/README.md
+++ b/blocks/mxschool_dash_faculty/README.md
@@ -34,5 +34,5 @@ v3.1 of this plugin was developed alongside v3.1 of the local_mxschool plugin in
 - Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 
 ## License
-As Moodle itself, this plugin is provided freely under the [GNU General Public License v3.0](/COPYING.txt). </ br>
+As Moodle itself, this plugin is provided freely under the [GNU General Public License v3.0](/COPYING.txt).  
 © 2022 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.

--- a/blocks/mxschool_dash_faculty/README.md
+++ b/blocks/mxschool_dash_faculty/README.md
@@ -21,17 +21,17 @@ This plugin has the following dependencies:
 
 ## Credits
 v4.0 of this plugin was developed alongside v4.0 of the local_mxschool plugin in 2022 by:
-- Aarav Mehta, Class of 2023 \<amehta@mxschool.edu\>
-- Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
-- The mxMoodle Development Team
+Aarav Mehta, Class of 2023 \<amehta@mxschool.edu\>  
+Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>  
+The mxMoodle Development Team
 
 v3.2 of this plugin was developed alongside v3.2 of the local_mxschool plugin in 2020 by:
-- Cannon Caspar, Class of 2021 \<cpcaspar@mxschool.edu\>
-- Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
+Cannon Caspar, Class of 2021 \<cpcaspar@mxschool.edu\>  
+Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 
 v3.1 of this plugin was developed alongside v3.1 of the local_mxschool plugin in 2019 by:
-- Jeremiah DeGreeff, Class of 2019 \<jrdegreeff@mxschool.edu\>
-- Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
+Jeremiah DeGreeff, Class of 2019 \<jrdegreeff@mxschool.edu\>  
+Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 
 ## License
 As Moodle itself, this plugin is provided freely under the [GNU General Public License v3.0](/COPYING.txt).  

--- a/blocks/mxschool_dash_faculty/README.md
+++ b/blocks/mxschool_dash_faculty/README.md
@@ -5,12 +5,19 @@ This block is for all faculty and provides links to reports defined by the local
 Student Data reports:
 - My Advisees: This is the student data report filtered by the Faculty's advisees. If the Faculty does not have advisees, then the report will default to All Advisors
 - My Dorm: This is the student data report filtered by the Faculty's assigned dorm. If the Faculty does not have an assigned dorm, then the report will default to All Dorms
-- Peer Tutoring: This is the Peer Tutoring report
+- View Deans' Permission Report (This is for approvers right now but it would be nice to show an Advisor View of this)
 - Student Vehicles: Student Vehicle report
 
 Check In reports:
 - Event Attendance: This is the general attendance report defaulting to the Faculty's assigned dorm. If the Faculty does not have an assigned dorm, then the report will default to All Dorms.
 - On-Campus Duty Report
+
+Peer Tutoring reports:
+(If view capability: Faculty)
+- View Peer Tutoring Report
+(If manage capability: Peer Tutoring Manager)
+- Manage Peer Tutoring Report
+- Manage Peer Tutoring Preferences
 
 ## Dependencies
 This plugin has the following dependencies:

--- a/blocks/mxschool_dash_faculty/README.md
+++ b/blocks/mxschool_dash_faculty/README.md
@@ -1,27 +1,28 @@
-# Middlesex's Dashboard Block for Peer Tutors
-Moodle block plugin written for Middlesex. Middlesex is an independent secondary school for boarding and day students in grades 9-12. Learn more at <https://mxschool.edu>.
-
-Moodle is the world’s open source learning platform. Learn more at <https://moodle.org>.
-
+# Middlesex's Dashboard Block for Faculty.
 ## Package Description
-This block provides an interface for all faculty to access reports defined by the local_mxschool and local_signout plugins.
+This block provides an interface for all faculty to access reports defined by the local_mxschool, local_signout, and local_peertutoring plugins.
 
 ## Dependencies
 This plugin has the following dependencies:
-- Moodle 3.7 (2019052000)
+- Moodle 4.0 (2022___)
 - [local_mxschool v3.2](/local/mxschool/README.md) (2020072200)
 - [local_signout v3.1](/local/mxschool/README.md) (2019081400)
+- [local_peertutoring v4.0](/local/peertutoring/README.md) (2022___)
 
 ## Credits
+v4.0 of this plugin was developed alongside v4.0 of the local_mxschool plugin in 2022 by:
+- Aarav Mehta, Class of 2023
+- Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
+- The mxMoodle Development Team
+
 v3.2 of this plugin was developed alongside v3.2 of the local_mxschool plugin in 2020 by:
-- Cannon Caspar, Class of 2021 <cpcaspar@mxschool.edu>
-- Charles J McDonald, Academic Technology Specialist <cjmcdonald@mxschool.edu>
+- Cannon Caspar, Class of 2021 \<cpcaspar@mxschool.edu\>
+- Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 
 v3.1 of this plugin was developed alongside v3.1 of the local_mxschool plugin in 2019 by:
-- Jeremiah DeGreeff, Class of 2019 <jrdegreeff@mxschool.edu>
-- Charles J McDonald, Academic Technology Specialist <cjmcdonald@mxschool.edu>
+- Jeremiah DeGreeff, Class of 2019 \<jrdegreeff@mxschool.edu\>
+- Charles J McDonald, Academic Technology Specialist \<cjmcdonald@mxschool.edu\>
 
 ## License
-As Moodle itself, this plugin is provided freely under the [GNU General Public License v3.0](/COPYING.txt).
-
-© 2019 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
+As Moodle itself, this plugin is provided freely under the [GNU General Public License v3.0](/COPYING.txt). </ br>
+© 2022 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.

--- a/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
@@ -57,11 +57,11 @@ class block_mxschool_dash_faculty extends block_base {
                         => '/local/mxschool/user_management/vehicle_report.php',
                 ), get_string('students', 'block_mxschool_dash_faculty')),
                 new local_mxschool\output\index(array(
-                    get_string('checkin:attendance_report', 'block_mxschool_dash_faculty')
+                    get_string('duty:attendance_report', 'block_mxschool_dash_faculty')
                         => '/local/mxschool/user_management/student_report.php',
-                    get_string('checkin:duty_report', 'block_mxschool_dash_faculty')
+                    get_string('duty:duty_report', 'block_mxschool_dash_faculty')
                         => '/local/mxschool/user_management/student_report.php',
-                ), get_string('checkin', 'block_mxschool_dash_faculty'))
+                ), get_string('duty', 'block_mxschool_dash_faculty'))
             );
             $this->content->text = array_reduce($renderables, function($html, $renderable) use($output) {
                 return $html . $output->render($renderable);

--- a/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
@@ -49,10 +49,8 @@ class block_mxschool_dash_faculty extends block_base {
                         => '/local/mxschool/user_management/student_report.php',
                     get_string('students:dorm_report', 'block_mxschool_dash_faculty')
                         => '/local/mxschool/user_management/student_report.php',
-                    get_string('students:peertutoring', 'block_mxschool_dash_faculty')
-                        => '/local/peertutoring/report.php',
-                    get_string('students:vehicle_report', 'block_mxschool_dash_faculty')
-                        => '/local/mxschool/user_management/vehicle_report.php',
+
+// TODO Add the Deans' permission report link in here
                     get_string('students:vehicle_report', 'block_mxschool_dash_faculty')
                         => '/local/mxschool/user_management/vehicle_report.php',
                 ), get_string('students', 'block_mxschool_dash_faculty')),
@@ -63,6 +61,25 @@ class block_mxschool_dash_faculty extends block_base {
                         => '/local/mxschool/user_management/student_report.php',
                 ), get_string('duty', 'block_mxschool_dash_faculty'))
             );
+
+// TODO Add links and capabilities for Peer Tutoring Reports here
+// TODO No, seriously, please check my syntax on this...
+        if (has_capability('local/peertutoring:view', , context_system::instance())) {
+            array_push($renderables,
+                new local_mxschool\output\index(array(
+                    get_string('peertutoring:ptview', 'block_mxschool_dash_faculty')
+                        => '/local/peertutoring/report.php',
+                ), get_string('peertutoring', 'block_mxschool_dash_faculty'))
+        } else if (has_capability('local/peertutoring:manage', , context_system::instance())) {
+            array_push($renderables,
+                new local_mxschool\output\index(array(
+                    get_string('peertutoring:ptmanage', 'block_mxschool_dash_faculty')
+                        => '/local/peertutoring/report.php',
+                    get_string('peertutoring:ptpreferences', 'block_mxschool_dash_faculty')
+                        => '/local/peertutoring/report.php',
+                ), get_string('peertutoring', 'block_mxschool_dash_faculty'))
+            );
+
             $this->content->text = array_reduce($renderables, function($html, $renderable) use($output) {
                 return $html . $output->render($renderable);
             }, '');

--- a/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Content for Middlesex's Dashboard Block for Faculty.
+ * Content for Middlesex's Faculty Dashboard Block
  *
  * @package     block_mxschool_dash_faculty
  * @author      mxMoodle Development Team

--- a/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
@@ -36,7 +36,9 @@ class block_mxschool_dash_faculty extends block_base {
 
     public function get_content() {
         global $PAGE, $USER;
-        if (isset($this->content)) return $this->content;
+        if (isset($this->content)) {
+            return $this->content;
+        }
 
         $this->content = new stdClass();
         if (has_capability('block/mxschool_dash_faculty:access', context_system::instance())) {
@@ -51,28 +53,16 @@ class block_mxschool_dash_faculty extends block_base {
                         => '/local/peertutoring/report.php',
                     get_string('students:vehicle_report', 'block_mxschool_dash_faculty')
                         => '/local/mxschool/user_management/vehicle_report.php',
+                    get_string('students:vehicle_report', 'block_mxschool_dash_faculty')
+                        => '/local/mxschool/user_management/vehicle_report.php',
                 ), get_string('students', 'block_mxschool_dash_faculty')),
                 new local_mxschool\output\index(array(
                     get_string('checkin:attendance_report', 'block_mxschool_dash_faculty')
                         => '/local/mxschool/user_management/student_report.php',
                     get_string('checkin:duty_report', 'block_mxschool_dash_faculty')
                         => '/local/mxschool/user_management/student_report.php',
-                ),
-
-                if (has_capability('local/mxschool:manage_deans_permission', context_system::instance())) {
-                    new local_mxschool\output\index(array(
-                        get_string('checkin:deans_permission_report', 'block_mxschool_dash_faculty')
-                            => '/local/mxschool/deans_permission/report.php',
-                    )
-                },
-                if (has_capability('block/mxschool_manage_tutoring:access', context_system::instance())) {
-                    new local_mxschool\output\index(array(
-                        get_string('checkin:deans_permission_report', 'block_mxschool_manage_tutoring')
-                            => '/local/peertutoring/report.php',
-                    ), get_string('checkin', 'block_mxschool_dash_faculty'))
-                },
+                ), get_string('checkin', 'block_mxschool_dash_faculty'))
             );
-
             $this->content->text = array_reduce($renderables, function($html, $renderable) use($output) {
                 return $html . $output->render($renderable);
             }, '');

--- a/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
@@ -57,16 +57,20 @@ class block_mxschool_dash_faculty extends block_base {
                         => '/local/mxschool/user_management/student_report.php',
                     get_string('checkin:duty_report', 'block_mxschool_dash_faculty')
                         => '/local/mxschool/user_management/student_report.php',
+                ),
 
-                    if (has_capability('local/mxschool:manage_deans_permission', context_system::instance())) {
+                if (has_capability('local/mxschool:manage_deans_permission', context_system::instance())) {
+                    new local_mxschool\output\index(array(
                         get_string('checkin:deans_permission_report', 'block_mxschool_dash_faculty')
-                            => '/local/mxschool/deans_permission/report.php'
-                    },
-                    if (has_capability('block/mxschool_manage_tutoring:access', context_system::instance())) {
+                            => '/local/mxschool/deans_permission/report.php',
+                    )
+                },
+                if (has_capability('block/mxschool_manage_tutoring:access', context_system::instance())) {
+                    new local_mxschool\output\index(array(
                         get_string('checkin:deans_permission_report', 'block_mxschool_manage_tutoring')
-                            => '/local/peertutoring/report.php'
-                    },
-                ), get_string('checkin', 'block_mxschool_dash_faculty'))
+                            => '/local/peertutoring/report.php',
+                    ), get_string('checkin', 'block_mxschool_dash_faculty'))
+                },
             );
 
             $this->content->text = array_reduce($renderables, function($html, $renderable) use($output) {

--- a/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/block_mxschool_dash_faculty.php
@@ -17,15 +17,15 @@
 /**
  * Content for Middlesex's Dashboard Block for Faculty.
  *
- * @package    block_mxschool_dash_faculty
- * @author     Cannon Caspar, Class of 2021 <cpcaspar@mxschool.edu>
- * @author     Charles J McDonald, Academic Technology Specialist <cjmcdonald@mxschool.edu>
- * @copyright  2020 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package     block_mxschool_dash_faculty
+ * @author      mxMoodle Development Team
+ * @copyright   2022 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
+// TODO Is this library required?
 require_once(__DIR__.'/../../local/mxschool/locallib.php');
 
 class block_mxschool_dash_faculty extends block_base {
@@ -36,28 +36,44 @@ class block_mxschool_dash_faculty extends block_base {
 
     public function get_content() {
         global $PAGE, $USER;
-        if (isset($this->content)) {
-            return $this->content;
-        }
+        if (isset($this->content)) return $this->content;
 
         $this->content = new stdClass();
         if (has_capability('block/mxschool_dash_faculty:access', context_system::instance())) {
             $output = $PAGE->get_renderer('local_mxschool');
-            $links = array(
-                get_string('student_report', 'block_mxschool_dash_faculty') => '/local/mxschool/user_management/student_report.php',
-                get_string('vehicle_report', 'block_mxschool_dash_faculty') => '/local/mxschool/user_management/vehicle_report.php',
-                get_string('duty_report', 'block_mxschool_dash_faculty') => '/local/signout/on_campus/duty_report.php',
-                get_string('attendance_report', 'block_mxschool_dash_faculty') => '/local/mxschool/checkin/attendance_report.php'
-                );
-                if(has_capability('local/mxschool:manage_deans_permission', context_system::instance())) {
-                    $links[get_string('deans_permission_report', 'block_mxschool_dash_faculty')] = '/local/mxschool/deans_permission/report.php';
-                }
-                if (has_capability('block/mxschool_manage_tutoring:access', context_system::instance())) {
-                    $links[get_string('report', 'block_mxschool_manage_tutoring')] = '/local/peertutoring/report.php';
-                }
-                $renderable = new local_mxschool\output\index($links);
-            $this->content->text = $output->render($renderable);
+            $renderables = array(
+                new local_mxschool\output\index(array(
+                    get_string('students:advisor_report', 'block_mxschool_dash_faculty')
+                        => '/local/mxschool/user_management/student_report.php',
+                    get_string('students:dorm_report', 'block_mxschool_dash_faculty')
+                        => '/local/mxschool/user_management/student_report.php',
+                    get_string('students:peertutoring', 'block_mxschool_dash_faculty')
+                        => '/local/peertutoring/report.php',
+                    get_string('students:vehicle_report', 'block_mxschool_dash_faculty')
+                        => '/local/mxschool/user_management/vehicle_report.php',
+                ), get_string('students', 'block_mxschool_dash_faculty')),
+                new local_mxschool\output\index(array(
+                    get_string('checkin:attendance_report', 'block_mxschool_dash_faculty')
+                        => '/local/mxschool/user_management/student_report.php',
+                    get_string('checkin:duty_report', 'block_mxschool_dash_faculty')
+                        => '/local/mxschool/user_management/student_report.php',
+
+                    if (has_capability('local/mxschool:manage_deans_permission', context_system::instance())) {
+                        get_string('checkin:deans_permission_report', 'block_mxschool_dash_faculty')
+                            => '/local/mxschool/deans_permission/report.php'
+                    },
+                    if (has_capability('block/mxschool_manage_tutoring:access', context_system::instance())) {
+                        get_string('checkin:deans_permission_report', 'block_mxschool_manage_tutoring')
+                            => '/local/peertutoring/report.php'
+                    },
+                ), get_string('checkin', 'block_mxschool_dash_faculty'))
+            );
+
+            $this->content->text = array_reduce($renderables, function($html, $renderable) use($output) {
+                return $html . $output->render($renderable);
+            }, '');
         }
+
         return $this->content;
     }
 

--- a/blocks/mxschool_dash_faculty/classes/privacy/provider.php
+++ b/blocks/mxschool_dash_faculty/classes/privacy/provider.php
@@ -15,12 +15,11 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Provider for Middlesex's Dashboard Block for Faculty.
+ * Provider for Middlesex's Faculty Dashboard Block
  *
  * @package     block_mxschool_dash_faculty
- * @author      Jeremiah DeGreeff, Class of 2019 <jrdegreeff@mxschool.edu>
- * @author      Charles J McDonald, Academic Technology Specialist <cjmcdonald@mxschool.edu>
- * @copyright   2019 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
+ * @author      mxMoodle Development Team
+ * @copyright   2022 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/blocks/mxschool_dash_faculty/db/access.php
+++ b/blocks/mxschool_dash_faculty/db/access.php
@@ -15,13 +15,12 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Capabilites for Middlesex's Dashboard Block for Faculty.
+ * Capabilites for Middlesex's Faculty Dashboard Block
  *
- * @package    block_mxschool_dash_faculty
- * @author     Jeremiah DeGreeff, Class of 2019 <jrdegreeff@mxschool.edu>
- * @author     Charles J McDonald, Academic Technology Specialist <cjmcdonald@mxschool.edu>
- * @copyright  2019 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package     block_mxschool_dash_faculty
+ * @author      mxMoodle Development Team
+ * @copyright   2022 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();

--- a/blocks/mxschool_dash_faculty/lang/en/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/lang/en/block_mxschool_dash_faculty.php
@@ -39,9 +39,9 @@ $string['students'] = 'Student Data';
 $string['students:advisor_report'] = 'My Advisees';
 $string['students:dorm_report'] = 'My Dorm';
 $string['students:peertutoring'] = 'Peer Tutoring';
+$string['students:deans_permission_report'] = 'Deans\' Permission Report';
 $string['students:vehicle_report'] = 'Student Vehicles';
 
-$string['checkin'] = 'Check In Data';
+$string['checkin'] = 'Check In';
 $string['checkin:attendance_report'] = 'Event Attendance';
 $string['checkin:duty_report'] = 'On-Campus Duty Report';
-$string['checkin:deans_permission_report'] = 'Deans\' Permission Report';

--- a/blocks/mxschool_dash_faculty/lang/en/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/lang/en/block_mxschool_dash_faculty.php
@@ -35,13 +35,13 @@ $string['mxschool_dash_faculty:access'] = 'Middlesex: Access Faculty Dashboard B
 $string['privacy:metadata'] = 'This block only provides links to other pages and does not store any user data.';
 
 // Links
-$string['students'] = 'Student Data';
+$string['students'] = 'Student Reports';
 $string['students:advisor_report'] = 'My Advisees';
 $string['students:dorm_report'] = 'My Dorm';
 $string['students:peertutoring'] = 'Peer Tutoring';
 $string['students:deans_permission_report'] = 'Deans\' Permission Report';
 $string['students:vehicle_report'] = 'Student Vehicles';
 
-$string['checkin'] = 'Check In';
-$string['checkin:attendance_report'] = 'Event Attendance';
-$string['checkin:duty_report'] = 'On-Campus Duty Report';
+$string['duty'] = 'Duty Reports';
+$string['duty:attendance_report'] = 'Event Attendance';
+$string['duty:duty_report'] = 'On-Campus Duty Report';

--- a/blocks/mxschool_dash_faculty/lang/en/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/lang/en/block_mxschool_dash_faculty.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * English language strings for Middlesex's Dashboard Block for Faculty.
+ * English language strings for Middlesex's Faculty Dashboard Block
  *
  * @package     block_mxschool_dash_faculty
  * @author      mxMoodle Development Team

--- a/blocks/mxschool_dash_faculty/lang/en/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/lang/en/block_mxschool_dash_faculty.php
@@ -17,28 +17,31 @@
 /**
  * English language strings for Middlesex's Dashboard Block for Faculty.
  *
- * @package    block_mxschool_dash_faculty
- * @author     Jeremiah DeGreeff, Class of 2019 <jrdegreeff@mxschool.edu>
- * @author     Charles J McDonald, Academic Technology Specialist <cjmcdonald@mxschool.edu>
- * @copyright  2019 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package     block_mxschool_dash_faculty
+ * @author      mxMoodle Development Team
+ * @copyright   2022 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 $string['pluginname'] = 'Faculty Dashboard Block';
-$string['blockname'] = 'Middlesex Faculty';
+$string['blockname'] = 'mxFaculty Reports';
 
-// Capabilities.
-$string['mxschool_dash_faculty:addinstance'] = 'Middlesex School: Add Faculty Dashboard Block';
-$string['mxschool_dash_faculty:myaddinstance'] = 'Middlesex School: Add Faculty Dashboard Block to Dashboard';
-$string['mxschool_dash_faculty:access'] = 'Middlesex School: Access Faculty Dashboard Block';
+// Capabilities
+$string['mxschool_dash_faculty:addinstance'] = 'Middlesex: Add Faculty Dashboard Block';
+$string['mxschool_dash_faculty:myaddinstance'] = 'Middlesex: Add Faculty Dashboard Block to Dashboard';
+$string['mxschool_dash_faculty:access'] = 'Middlesex: Access Faculty Dashboard Block';
 
-// Privacy.
+// Privacy
 $string['privacy:metadata'] = 'This block only provides links to other pages and does not store any user data.';
 
-// Links.
-$string['student_report'] = 'Student Data Report';
-$string['vehicle_report'] = 'Student Vehicles Report';
-$string['duty_report'] = 'On-Campus Duty Report';
-$string['deans_permission_report'] = 'Deans\' Permission Report';
-$string['deans_permission_preferences'] = 'Deans\' Permission Preferences';
-$string['attendance_report'] = 'Student Attendance Report';
+// Links
+$string['students'] = 'Student Data';
+$string['students:advisor_report'] = 'My Advisees';
+$string['students:dorm_report'] = 'My Dorm';
+$string['students:peertutoring'] = 'Peer Tutoring';
+$string['students:vehicle_report'] = 'Student Vehicles';
+
+$string['checkin'] = 'Check In Data';
+$string['checkin:attendance_report'] = 'Event Attendance';
+$string['checkin:duty_report'] = 'On-Campus Duty Report';
+$string['checkin:deans_permission_report'] = 'Deans\' Permission Report';

--- a/blocks/mxschool_dash_faculty/lang/en/block_mxschool_dash_faculty.php
+++ b/blocks/mxschool_dash_faculty/lang/en/block_mxschool_dash_faculty.php
@@ -38,10 +38,13 @@ $string['privacy:metadata'] = 'This block only provides links to other pages and
 $string['students'] = 'Student Reports';
 $string['students:advisor_report'] = 'My Advisees';
 $string['students:dorm_report'] = 'My Dorm';
-$string['students:peertutoring'] = 'Peer Tutoring';
 $string['students:deans_permission_report'] = 'Deans\' Permission Report';
 $string['students:vehicle_report'] = 'Student Vehicles';
 
-$string['duty'] = 'Duty Reports';
 $string['duty:attendance_report'] = 'Event Attendance';
 $string['duty:duty_report'] = 'On-Campus Duty Report';
+
+$string['peertutoring'] = 'Peer Tutoring';
+$string['peertutoring:ptview'] = 'View Peer Tutoring';
+$string['peertutoring:ptmanage'] = 'Manage Peer Tutoring';
+$string['peertutoring:ptpreferences'] = 'Peer Tutoring Preferences';

--- a/blocks/mxschool_dash_faculty/version.php
+++ b/blocks/mxschool_dash_faculty/version.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Middlesex's Dashboard Block for Faculty.
+ * Middlesex's Faculty Dashboard Block
  *
  * @package     block_mxschool_dash_faculty
  * @author      mxMoodle Development Team

--- a/blocks/mxschool_dash_faculty/version.php
+++ b/blocks/mxschool_dash_faculty/version.php
@@ -17,21 +17,21 @@
 /**
  * Middlesex's Dashboard Block for Faculty.
  *
- * @package    block_mxschool_dash_faculty
- * @author     Cannon Caspar, Class of 2021 <cpcaspar@mxschool.edu>
- * @author     Charles J McDonald, Academic Technology Specialist <cjmcdonald@mxschool.edu>
- * @copyright  2020 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package     block_mxschool_dash_faculty
+ * @author      mxMoodle Development Team
+ * @copyright   2022 Middlesex School, 1400 Lowell Rd, Concord MA 01742 All Rights Reserved.
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_mxschool_dash_faculty';
 $plugin->version = 2022040505;
-$plugin->release = 'v3.2';
+$plugin->release = 'v4.0';
 $plugin->requires = 2019052000; // Moodle 3.7.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = array(
     'local_mxschool' => 2020072200, // MXSchool v3.2.
     'local_signout' => 2019081400 // eSignout v3.1.
+    'local_peertutoring' => 2022040000 // peertutoring v4.0.
 );

--- a/blocks/mxschool_dash_faculty/version.php
+++ b/blocks/mxschool_dash_faculty/version.php
@@ -26,12 +26,12 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_mxschool_dash_faculty';
-$plugin->version = 2022040505;
+$plugin->version = 2022040900;
 $plugin->release = 'v4.0';
 $plugin->requires = 2019052000; // Moodle 3.7.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = array(
     'local_mxschool' => 2020072200, // MXSchool v3.2.
-    'local_signout' => 2019081400 // eSignout v3.1.
+    'local_signout' => 2019081400, // eSignout v3.1.
     'local_peertutoring' => 2022040000 // peertutoring v4.0.
 );

--- a/local/peertutoring/version.php
+++ b/local/peertutoring/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_peertutoring';
-$plugin->version = 20190901113;
+$plugin->version = 2022040000;
 $plugin->release = 'v3.1';
 $plugin->requires = 2019052000; // Moodle 3.7.
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Advisor Functionality
- [x] Rewrite the Faculty Dashboard Block to present Advisor and Dorm versions of student reports
- [x] Create sections for student info, duty info
~~Health Center Info for your advisees ??? This is a great idea but will require we enter health data into Moodle which might present a security issue.~~
~~Add Deans' Permission Report for folks with View or Manage capability~~

Student Data Report
- [x] Add link "My Advisees" that goes to Student Data Report, filtered by Advisees
- [x] Add link "My Dorm" that goes to Student Data Report, filtered by Dorm
If Faculty does not have advisees or is not assigned to a dorm, they will see the default "All Students" version of this report

Peer Tutoring Report
PR #136 Adds an Advisor Filter to the Peer Tutoring Report.
- [x] Add Link to Peer Tutoring Report to this block filtered by Advisor
  - [x] Add link to  Peer Tutoring Report for Peer Tutoring Manager
  - [x] Add link to  Peer Tutoring Preferences page for Peer Tutoring Manager